### PR TITLE
feat: 시큐리티 토큰 예외처리 및 업그레이드

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/config/security/SecurityConfig.java
+++ b/src/main/java/com/supercoding/hanyipman/config/security/SecurityConfig.java
@@ -42,12 +42,12 @@ public class SecurityConfig {
         httpSecurity
                 .cors().and() // 찾아보기
                 .csrf().disable() // token을 사용하는 방식이므로 csrf 해제
+//                .anonymous().disable() // "anonymousUser" 비활성화
                 .addFilterBefore(new JwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-//                .anonymous().disable()
                 .authorizeHttpRequests()// 요청에 대한 권한 설정
                 .antMatchers("/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/supercoding/hanyipman/controller/MyInfoController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/MyInfoController.java
@@ -9,6 +9,7 @@ import com.supercoding.hanyipman.error.domain.LoginErrorCode;
 import com.supercoding.hanyipman.error.domain.TokenErrorCode;
 import com.supercoding.hanyipman.error.domain.UserErrorCode;
 import com.supercoding.hanyipman.repository.UserRepository;
+import com.supercoding.hanyipman.security.JwtToken;
 import com.supercoding.hanyipman.service.MyInfoService;
 import com.supercoding.hanyipman.utils.ApiUtils;
 import io.swagger.annotations.Api;
@@ -36,8 +37,8 @@ public class MyInfoController {
 
     @GetMapping("/users/my-info")
     @Operation(summary = "구매자 마이페이지 API", description = "회원의 정보와 회원에 등록어 주소 리스트가 출력됩니다.")
-    public Response<MyInfoResponse> buyerUserMyInfo(@AuthenticationPrincipal CustomUserDetail userDetail) {
-        return ApiUtils.success(HttpStatus.OK, "유저 마이페이지 응답 성공", myInfoService.getUserInfoForMyPage(findUserByUserId(userDetail)));
+    public Response<MyInfoResponse> buyerUserMyInfo() {
+        return ApiUtils.success(HttpStatus.OK, "유저 마이페이지 응답 성공", myInfoService.getUserInfoForMyPage(JwtToken.user()));
     }
 
     public User findUserByUserId(CustomUserDetail userDetail) {

--- a/src/main/java/com/supercoding/hanyipman/controller/S3TestController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/S3TestController.java
@@ -1,9 +1,9 @@
 package com.supercoding.hanyipman.controller;
 
 import com.supercoding.hanyipman.dto.vo.Response;
+import com.supercoding.hanyipman.enums.FilePath;
 import com.supercoding.hanyipman.service.AwsS3Service;
 import com.supercoding.hanyipman.utils.ApiUtils;
-import com.supercoding.hanyipman.utils.FilePath;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;

--- a/src/main/java/com/supercoding/hanyipman/security/JwtToken.java
+++ b/src/main/java/com/supercoding/hanyipman/security/JwtToken.java
@@ -1,0 +1,48 @@
+package com.supercoding.hanyipman.security;
+
+import com.supercoding.hanyipman.dto.user.CustomUserDetail;
+import com.supercoding.hanyipman.entity.User;
+import com.supercoding.hanyipman.error.CustomException;
+import com.supercoding.hanyipman.error.domain.LoginErrorCode;
+import com.supercoding.hanyipman.error.domain.TokenErrorCode;
+import com.supercoding.hanyipman.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Getter
+@NoArgsConstructor
+@Configuration
+public class JwtToken {
+    private static UserRepository userRepository;
+    @Autowired
+    public JwtToken(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+    public static User user() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            // 게스트 권한이면 예외처리
+            if (principal == "anonymousUser") throw new CustomException(TokenErrorCode.ACCESS_DENIED);
+
+            // 토큰데이터 확인 유저객체 return
+            if (principal instanceof UserDetails) {
+                CustomUserDetail userDetails = (CustomUserDetail) principal;
+                return userRepository.findById(userDetails.getUserId()).orElseThrow(() -> new CustomException(TokenErrorCode.ACCESS_DENIED));
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/supercoding/hanyipman/security/JwtTokenProvider.java
+++ b/src/main/java/com/supercoding/hanyipman/security/JwtTokenProvider.java
@@ -26,17 +26,11 @@ import java.util.Date;
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
-
-
     private static String secretKeySource;
-
     @Value("${secret-key-source}")
     public void setSecretKeySource(String value) {
         secretKeySource = value;
     }
-
-
-    private final UserDetailsService userDetailsService;
     private final CustomUserDetailService customUserDetailService;
 
     public static String createToken(User loginUser) {
@@ -58,27 +52,6 @@ public class JwtTokenProvider {
         UserDetails userDetails = customUserDetailService.loadUserByUsername(userEmail);
         return new UsernamePasswordAuthenticationToken(userDetails, jwtToken, userDetails.getAuthorities());
     }
-
-    public String getEmail(String jwtToken) {
-        return Jwts.parser().setSigningKey(secretKeySource).parseClaimsJws(jwtToken).getBody().get("email", String.class);
-    }
-
-    public Claims getJwtParser(String jwtToken) {
-        return Jwts.parser().setSigningKey(secretKeySource).parseClaimsJwt(jwtToken).getBody();
-    }
-
-    public AuthenticationTestDto getAuthenticationTest(String token) {
-        String userEmail = Jwts.parser().setSigningKey(secretKeySource).parseClaimsJws(token).getBody().get("email").toString();
-        UserDetails userDetails = customUserDetailService.loadUserByUsername(userEmail);
-
-        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-
-        AuthenticationTestDto authenticationTestDto = new AuthenticationTestDto();
-        AuthenticationTestDto authentication = authenticationTestDto.toAuthentication(usernamePasswordAuthenticationToken);
-
-        return authentication;
-    }
-
 
     // 토큰을 검증함
     public boolean validateToken(String token) {

--- a/src/main/java/com/supercoding/hanyipman/service/MyInfoService.java
+++ b/src/main/java/com/supercoding/hanyipman/service/MyInfoService.java
@@ -10,9 +10,11 @@ import com.supercoding.hanyipman.error.domain.BuyerErrorCode;
 import com.supercoding.hanyipman.repository.AddressRepository;
 import com.supercoding.hanyipman.repository.BuyerRepository;
 import com.supercoding.hanyipman.repository.UserRepository;
+import com.supercoding.hanyipman.security.JwtToken;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +30,8 @@ public class MyInfoService {
 
     private final BuyerRepository buyerRepository;
 
+    @Transactional
     public MyInfoResponse getUserInfoForMyPage(User user) {
-        user.getRole();
         if (Objects.equals(user.getRole(), "SELLER")) {
             throw new CustomException(BuyerErrorCode.INVALID_SELLER);
         }


### PR DESCRIPTION
1. 기존 컨트롤러단에서 토큰이 없으면 500 null 에러가 났지만 JwtToken.user()에 예외처리를 해두어서 사용하시면
됩니다.

2. JwtToken.user()를 불러오시면 기존 Long과 String타입이 아닌 User객체를 불러올 수 있습니다.

사용법: 기존 컨트롤러 매개변수 위치에 있던
@AuthenticationPricipal를 사용하지 않고 유저
객체가 필요한 곳에
JwtToken.user()를 작성하여 유저객체를 불러올 수 있습니다.

기존 ->[컨트롤러 매개변수 위치] @AuthenticationPrincipal CustomUserDetail userDetail

변경 ->[모든곳] JwtToken.user();