### PR TITLE
Fix: FilePath 맨 앞 '/' 문자 제거

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/enums/FilePath.java
+++ b/src/main/java/com/supercoding/hanyipman/enums/FilePath.java
@@ -3,8 +3,8 @@ package com.supercoding.hanyipman.enums;
 public enum FilePath {
     TEST_DIR("user/image/"),
     SEPARATE_POINT(".com/"),
-    SHOP_DIR("/shop/"),
-    REVIEW_DIR("/review/");
+    SHOP_DIR("shop/"),
+    REVIEW_DIR("review/");
 
     FilePath(String path) {
         this.path = path;


### PR DESCRIPTION
filePath 앞에 /가 두개들어가 이미지 로드가 비정상적으로 동작하여 '/' 문자 하나 제거했습니다.
리뷰쪽도 같이 제거했습니다.
@G1-H 