### PR TITLE
Feature/주소중복검사api

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/controller/AddressController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/AddressController.java
@@ -65,5 +65,11 @@ public class AddressController {
         addressService.setDefaultAddress(JwtToken.user(), defaultAddressId);
         return ApiUtils.success(HttpStatus.OK, "기본 주소가 변경되었습니다.", null);
     }
+
+    @Operation(summary = "주소 중복 확인", description = "내 배송지 리스트를 조회해 중복 검사를 시행합니다")
+    @GetMapping(value = "/duplication", headers = "X-API-VERSION=1")
+    public Response<Boolean> checkDuplicationAddress(String mapId) {
+        return ApiUtils.success(HttpStatus.OK, "카카오 mapId 중복 체크 검사 결과", addressService.checkDuplicationAddress(mapId));
+    }
 }
 

--- a/src/main/java/com/supercoding/hanyipman/controller/BuyerShopController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/BuyerShopController.java
@@ -81,6 +81,7 @@ public class BuyerShopController {
     @GetMapping(value = "/{shopId}/review-average", headers = "X-API-VERSION=1")
     public Response<Double> viewShopReviewAverage(@PathVariable String shopId) {
 
+
         return ApiUtils.success(HttpStatus.OK, "해당 가게의 평균 리뷰 별점 조회에 성공했습니다.", reviewService.viewShopReviewAverage(shopId));
     }
 

--- a/src/main/java/com/supercoding/hanyipman/entity/User.java
+++ b/src/main/java/com/supercoding/hanyipman/entity/User.java
@@ -3,6 +3,9 @@ package com.supercoding.hanyipman.entity;
 import com.supercoding.hanyipman.dto.myInfo.request.SellerUpdateInfoRequest;
 import com.supercoding.hanyipman.dto.user.request.BuyerSignUpRequest;
 import com.supercoding.hanyipman.dto.user.request.SellerSignUpRequest;
+import com.supercoding.hanyipman.error.CustomException;
+import com.supercoding.hanyipman.error.domain.BuyerErrorCode;
+import com.supercoding.hanyipman.error.domain.SellerErrorCode;
 import com.supercoding.hanyipman.security.UserRole;
 import com.supercoding.hanyipman.service.MyInfoService;
 import lombok.*;
@@ -14,6 +17,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 import javax.persistence.*;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Entity
@@ -64,6 +68,14 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Seller seller;
+
+    public Seller validSeller() {
+        return Optional.ofNullable(this.seller).orElseThrow(() -> new CustomException(SellerErrorCode.NOT_SELLER));
+    }
+
+    public Buyer validBuyer() {
+        return Optional.ofNullable(this.buyer).orElseThrow(() -> new CustomException(BuyerErrorCode.NOT_BUYER));
+    }
 
     public static User toSellerSignup(SellerSignUpRequest request, String password) {
         return User.builder()

--- a/src/main/java/com/supercoding/hanyipman/repository/AddressRepository.java
+++ b/src/main/java/com/supercoding/hanyipman/repository/AddressRepository.java
@@ -36,4 +36,6 @@ public interface AddressRepository extends JpaRepository<Address, Long> {
 
     List<Address> findAllByBuyerAndIsDefaultFalseOrderByIdDesc(Buyer buyer);
 
+    Boolean existsAddressByMapIdAndBuyer(String mapId, Buyer buyer);
+
 }

--- a/src/main/java/com/supercoding/hanyipman/service/AddressService.java
+++ b/src/main/java/com/supercoding/hanyipman/service/AddressService.java
@@ -11,6 +11,7 @@ import com.supercoding.hanyipman.error.domain.AddressErrorCode;
 import com.supercoding.hanyipman.error.domain.BuyerErrorCode;
 import com.supercoding.hanyipman.repository.AddressRepository;
 import com.supercoding.hanyipman.repository.BuyerRepository;
+import com.supercoding.hanyipman.security.JwtToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -111,6 +112,12 @@ public class AddressService {
             }
             return address;
         }).collect(Collectors.toList());
+    }
+
+    public Boolean checkDuplicationAddress(String mapId) {
+        Buyer buyer = JwtToken.user().validBuyer();
+
+        return addressRepository.existsAddressByMapIdAndBuyer(mapId, buyer);
     }
 }
 


### PR DESCRIPTION
# 개요
- 주소 중복 검사API를 작성했습니다.

# 작업사항
- 리턴이 true면 중복, false 면 미중복 리턴값에 따른 분기는 지환님께 전달해두었습니다.

# 변경로직(optional)
- User 엔티티안에 buyer과 seller을 바로 널검사 포함해서 불러올 수 있는 로직을 작성해두었습니다.
- 
![image](https://github.com/Han-Yip-Man/Han-Yip-Man-back/assets/99154108/fb24474c-f610-4608-9ff3-cfda368ad638)
- 다만 현재 JwtToken.user() 객체 자체에서 null이 리턴될 수 있어 이 부분은 추후 리팩토링이 필요해보입니다.
