### PR TITLE
Fix: 파일 충돌로 인한 가게 이름 중복 API 에러 정상 작동하도록 수정

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/controller/BuyerShopController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/BuyerShopController.java
@@ -81,6 +81,7 @@ public class BuyerShopController {
     @GetMapping(value = "/{shopId}/review-average", headers = "X-API-VERSION=1")
     public Response<Double> viewShopReviewAverage(@PathVariable String shopId) {
 
+
         return ApiUtils.success(HttpStatus.OK, "해당 가게의 평균 리뷰 별점 조회에 성공했습니다.", reviewService.viewShopReviewAverage(shopId));
     }
 

--- a/src/main/java/com/supercoding/hanyipman/controller/SellerShopController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/SellerShopController.java
@@ -74,7 +74,7 @@ public class SellerShopController {
     }
 
     @Operation(summary = "가게 이름 중복 조회", description = "가게 이름을 요청하여 내가 관리중인 가게 중 중복 이름이 있는지 검사합니다.")
-    @GetMapping(value = "/shops/duplication", headers = "X-API-VERSION=1", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @GetMapping(value = "/shops/duplication", headers = "X-API-VERSION=1")
     public Response<Void> checkDuplicationShopName(String shopName) {
         sellerShopService.checkDuplicationShopName(shopName);
         return ApiUtils.success(HttpStatus.OK, "내가 관리중인 가게중에 중복된 상호명이 없습니다.", null);


### PR DESCRIPTION
# 개요
- 파일 충돌로 인한 가게 이름 중복 에러

# 작업사항
- 원인 코드 제거
