### PR TITLE
Fix : 웹소켓 서버 접속 불가 문제 해결을 위한 호스트명 변경

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/config/websocket/WebSocketConfig.java
+++ b/src/main/java/com/supercoding/hanyipman/config/websocket/WebSocketConfig.java
@@ -10,7 +10,7 @@ public class WebSocketConfig  {
     @Bean
     public SocketIOServer socketIOServer() {
         com.corundumstudio.socketio.Configuration config = new com.corundumstudio.socketio.Configuration();
-        config.setHostname("localhost");
+        config.setHostname("54.180.103.214");
         config.setPort(8088); // 포트를 필요에 따라 수정
 
         return new SocketIOServer(config);


### PR DESCRIPTION
# 개요
- 웹 소켓 서버 접속 불가 문제 해결
# 작업사항
- 호스트명 localhost -> 실제 서버 주소 로 변경
