### PR TITLE
Refactor: 음식점 리스트 정렬 타입따라 커서 변경하는 로직 추가

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/request/ViewShopListRequest.java
+++ b/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/request/ViewShopListRequest.java
@@ -20,5 +20,6 @@ public class ViewShopListRequest {
     private Integer size;
     private String searchKeyword;
     private String sortType;
-    private Long cursor;
+    private Long cursorId;
+    private String cursorValue;
 }

--- a/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/response/ShopList.java
+++ b/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/response/ShopList.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.text.DecimalFormat;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/response/ViewShopListResponse.java
+++ b/src/main/java/com/supercoding/hanyipman/dto/Shop/buyer/response/ViewShopListResponse.java
@@ -14,6 +14,6 @@ import java.util.List;
 public class ViewShopListResponse {
 
     private List<ShopList> shopLists;
-    private Long nextCursor;
-
+    private Long nextCursorId;
+    private String nextCursorValue;
 }


### PR DESCRIPTION
# 개요
- 음식점 리스트 정렬 타입따라 커서 변경하는 로직 추가

# 작업사항
- 음식점 리스트 정렬 타입따라 커서 변경하는 로직 추가

# 변경로직(optional)
- 
![image](https://github.com/Han-Yip-Man/Han-Yip-Man-back/assets/99154108/65890e1d-046a-450a-acd7-b96a663ddacc)

커서로 받을 필드 변수 하나 추가
