### PR TITLE
Refactor : 결제 로직에 주문의 가게별 순서 설정

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/repository/order/OrderRepository.java
+++ b/src/main/java/com/supercoding/hanyipman/repository/order/OrderRepository.java
@@ -48,4 +48,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByOrderStatusAndShopAndOrderSequenceAfter(OrderStatus orderStatus,Shop shop, Integer start);
 
+    Optional<List<Order>> findByShopAndOrderStatus(Shop shop, OrderStatus orderStatus);
+
 }


### PR DESCRIPTION


# 개요
- 결제 로직에 주문의 가게별 순서 설정

# 작업사항
- 결제 시 주문이 PAID로 상태가 변경 될 때, 가게의 PAID 주문의 순서 중 마지막 순서로 sequence값 설정

