### PR TITLE
fix: 카카오 로그인 후 주소 null 처리

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/controller/AddressController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/AddressController.java
@@ -36,7 +36,9 @@ public class AddressController {
     @GetMapping(headers = "X-API-VERSION=1")
     @Operation(summary = "주소 조회", description = "나의 등록된 주소 모두를 불러옵니다.")
     public Response<List<AddressListResponse>> getAddressList() {
-        return ApiUtils.success(HttpStatus.OK, JwtToken.user().getEmail() + " 유저의 등록된 주소입니다.", addressService.getAddressList(JwtToken.user().validBuyer()));
+        List<AddressListResponse> addressList = addressService.getAddressList(JwtToken.user().validBuyer());
+        if (addressList.isEmpty()) addressList.add(AddressListResponse.toNullAddressResponse());
+        return ApiUtils.success(HttpStatus.OK, JwtToken.user().getEmail() + " 유저의 등록된 주소입니다.", addressList);
     }
 
     // 주소 수정
@@ -55,6 +57,7 @@ public class AddressController {
         String deleteAddress = addressService.sellerDeleteAddress(JwtToken.user().getBuyer(), addressId);
         return ApiUtils.success(HttpStatus.NO_CONTENT, deleteAddress + " 주소 삭제 완료", null);
     }
+
     // 기본 주소 등록
     @Operation(summary = "기본 주소 설정", description = "기본 배송지로 선택할 주소를 선택합니다.")
     @PostMapping(value = "/set-default-address", headers = "X-API-VERSION=1")

--- a/src/main/java/com/supercoding/hanyipman/controller/MyInfoController.java
+++ b/src/main/java/com/supercoding/hanyipman/controller/MyInfoController.java
@@ -1,8 +1,9 @@
 package com.supercoding.hanyipman.controller;
 
 import com.supercoding.hanyipman.advice.annotation.TimeTrace;
-import com.supercoding.hanyipman.dto.myInfo.response.MyInfoResponse;
 import com.supercoding.hanyipman.dto.myInfo.request.SellerUpdateInfoRequest;
+import com.supercoding.hanyipman.dto.myInfo.response.MyInfoAddressResponse;
+import com.supercoding.hanyipman.dto.myInfo.response.MyInfoResponse;
 import com.supercoding.hanyipman.dto.vo.Response;
 import com.supercoding.hanyipman.security.JwtToken;
 import com.supercoding.hanyipman.service.MyInfoService;
@@ -25,7 +26,10 @@ public class MyInfoController {
     @GetMapping(value = "/users/my-info", headers = "X-API-VERSION=1")
     @Operation(summary = "구매자, 판매자 마이페이지 API", description = "회원은 나의정보 및 등록주소 표시, 사장은 나의정보 포시")
     public Response<MyInfoResponse> buyerUserMyInfo() {
-        return ApiUtils.success(HttpStatus.OK, "마이페이지 응답 성공", myInfoService.getUserInfoForMyPage(JwtToken.user()));
+        MyInfoResponse userInfoForMyPage = myInfoService.getUserInfoForMyPage(JwtToken.user());
+        if (userInfoForMyPage.getAddressList().isEmpty())
+            userInfoForMyPage.getAddressList().add(MyInfoAddressResponse.toNullAddressResponse());
+        return ApiUtils.success(HttpStatus.OK, "마이페이지 응답 성공", userInfoForMyPage);
     }
 
     @PatchMapping(value = "/sellers/my-info", headers = "X-API-VERSION=1")

--- a/src/main/java/com/supercoding/hanyipman/dto/address/response/AddressListResponse.java
+++ b/src/main/java/com/supercoding/hanyipman/dto/address/response/AddressListResponse.java
@@ -33,4 +33,17 @@ public class AddressListResponse {
                 .mapId(address.getMapId())
                 .build();
     }
+
+    public static AddressListResponse toNullAddressResponse() {
+        return AddressListResponse.builder()
+                .addressId(null)
+                .address(null)
+                .addressDetail(null)
+                .latitude(null)
+                .longitude(null)
+                .isDefault(null)
+                .roadAddress(null)
+                .mapId(null)
+                .build();
+    }
 }

--- a/src/main/java/com/supercoding/hanyipman/dto/myInfo/response/MyInfoAddressResponse.java
+++ b/src/main/java/com/supercoding/hanyipman/dto/myInfo/response/MyInfoAddressResponse.java
@@ -31,5 +31,16 @@ public class MyInfoAddressResponse {
                 .roadAddress(addressList.getRoadAddress())
                 .mapId(addressList.getMapId())
                 .build();
+    }  public static MyInfoAddressResponse toNullAddressResponse() {
+        return MyInfoAddressResponse.builder()
+                .addressNumber(null)
+                .address(null)
+                .detailAddress(null)
+                .latitude(null)
+                .longitude(null)
+                .isDefault(null)
+                .roadAddress(null)
+                .mapId(null)
+                .build();
     }
 }

--- a/src/main/java/com/supercoding/hanyipman/service/AddressService.java
+++ b/src/main/java/com/supercoding/hanyipman/service/AddressService.java
@@ -57,7 +57,7 @@ public class AddressService {
             throw new CustomException(AddressErrorCode.ADDRESS_DATA_EXCEED_LIMIT);
         Address address = addressRepository.findByBuyerAndId(buyer, addressId).orElseThrow(() -> new CustomException(AddressErrorCode.ADDRESS_NOT_FOUND));
         // 삭제하려는 주소가 기본 주소로 등록되어 있을 때 최근 주소를 기본주소로 설정
-        if (address.getIsDefault()) {
+        if (Boolean.TRUE.equals(address.getIsDefault())) {
             List<Address> addresses = addressRepository.findAllByBuyerAndIsDefaultFalseOrderByIdDesc(buyer);
             setDefaultAddress(buyer, addresses.get(0).getId());
         }
@@ -75,6 +75,7 @@ public class AddressService {
         if (addressList.stream().noneMatch(address -> address.getId().equals(defaultAddressId)))
             throw new CustomException(AddressErrorCode.MY_ADDRESS_ONLY);
 
+        // 기본값이 해당 값만 true 나머지는 모두 false처리
         addressList.stream().peek(address -> {
             if (address.getId().equals(defaultAddressId)) {
                 address.setIsDefault(true);
@@ -101,7 +102,7 @@ public class AddressService {
 
     // 카카오 mapId 중복 예외처리
     private void validateUniqueAddressId(Buyer buyer, AddressRegisterRequest request) {
-        if (addressRepository.existsAddressByMapIdAndBuyer(request.getMapId(), buyer))
+        if (Boolean.TRUE.equals(addressRepository.existsAddressByMapIdAndBuyer(request.getMapId(), buyer)))
             throw new CustomException(AddressErrorCode.DUPLICATE_ADDRESS);
     }
 

--- a/src/main/java/com/supercoding/hanyipman/service/MyInfoService.java
+++ b/src/main/java/com/supercoding/hanyipman/service/MyInfoService.java
@@ -49,9 +49,6 @@ public class MyInfoService {
 
         }
         Buyer buyer = buyerRepository.findByUser(user).orElseThrow(() -> new CustomException(BuyerErrorCode.NOT_BUYER));
-        if (buyer == null) {
-            throw new CustomException(BuyerErrorCode.INVALID_BUYER);
-        }
 
         List<Address> addressList = addressRepository.findAllByBuyer(buyer);
         List<MyInfoAddressResponse> myInfoAddressResponses = addressList.stream().map(MyInfoAddressResponse::toMyAddressResponse).collect(Collectors.toList());
@@ -70,7 +67,6 @@ public class MyInfoService {
         validatePasswordConfirmation(password, passwordCheck, request);
         Seller seller = sellerRepository.findByUser(user).orElseThrow(() -> new CustomException(SellerErrorCode.NOT_SELLER));
 
-        // TODO: 영속성 적용해서 데이터 업데이트 하기
         sellerRepository.save(seller.updateBusinessNum(seller, request));
         userRepository.save(sellerUpdateMyInfo(user, seller, request));
     }


### PR DESCRIPTION
기본 주소값이 없을 시 null으로 나오게 추가하였습니다.

# 개요
- 카카오 로그인 후 주소 불러오지 못하는 버그 수정

# 작업사항
- 주소가 없으면 반값이 아닌 null 값이 출력되도록 하였습니다.
- 
# 변경로직(optional)
- 주소 비교 후 없으면 null반환 로직 추가
