### PR TITLE
결제 중 결제 취소/결제 실패일 때 사용자 쿠폰 되살리는 로직 추가

### DIFF
--- a/src/main/java/com/supercoding/hanyipman/service/PaymentService.java
+++ b/src/main/java/com/supercoding/hanyipman/service/PaymentService.java
@@ -15,6 +15,7 @@ import com.supercoding.hanyipman.enums.EventName;
 import com.supercoding.hanyipman.enums.OrderStatus;
 import com.supercoding.hanyipman.error.domain.CartErrorCode;
 import com.supercoding.hanyipman.error.domain.ShopErrorCode;
+import com.supercoding.hanyipman.repository.BuyerCouponRepository;
 import com.supercoding.hanyipman.repository.cart.CartRepository;
 import com.supercoding.hanyipman.repository.cart.EmCartRepository;
 import com.supercoding.hanyipman.repository.order.OrderRepository;
@@ -57,6 +58,7 @@ public class PaymentService {
     private final RestTemplate restTemplate;
     private final OrderService orderService;
     private final SseMessageService sseService;
+    private final BuyerCouponRepository buyerCouponRepository;
     private static final String API_BASE_URL = "https://api.iamport.kr";
     private static final String KAKAOPAY_BASE_URL = "https://kapi.kakao.com";
 
@@ -317,6 +319,7 @@ public class PaymentService {
         HttpEntity<?> httpEntity = new HttpEntity<>(params, headers);
 
         ResponseEntity<KakaoPayReadyResponse> kakaoPayReadyResponse = kakaoTemplate.exchange(KAKAOPAY_BASE_URL + "/v1/payment/ready", HttpMethod.POST, httpEntity, KakaoPayReadyResponse.class);
+
         if (kakaoPayReadyResponse.getStatusCode() == HttpStatus.OK && kakaoPayReadyResponse.getBody() != null) {
             // 응답값으로 merchant_uid 포함
             kakaoPayReadyResponse.getBody().setMerchant_uid(merchant_uid);
@@ -679,6 +682,11 @@ public class PaymentService {
             cart.setIsDeleted(false);
             cartRepository.save(cart);
         });
+        // buyerCoupon 되살리기
+        BuyerCoupon buyerCoupon = order.getBuyerCoupon();
+        if (order.getBuyerCoupon() != null) {
+            buyerCoupon.setEnabled(true);
+            buyerCouponRepository.save(buyerCoupon);}
     }
 
     private void setOrderSequence(Order order) {


### PR DESCRIPTION
# 개요
- 결제 중 결제 취소/결제 실패일 때 사용자 쿠폰 되살리는 로직 추가

# 작업사항
- 결제 중 결제 취소/결제 실패일 때 사용자 쿠폰 되살리는 로직 추가

# 변경로직(optional)
- 결제 중 결제 취소/결제 실패일 때 사용자 쿠폰 되살리는 로직 추가
